### PR TITLE
Refactor VPS setup: Clean logs and run Ollama via Docker with resourc…

### DIFF
--- a/nginx-proxy-manager/docker-compose.yml
+++ b/nginx-proxy-manager/docker-compose.yml
@@ -31,8 +31,12 @@ services:
       POSTGRES_PASSWORD: "llmpasswd123"
       POSTGRES_DB: "npm"
     volumes:
-      - ./postgres:/var/lib/postgresql/data
+      - db-data:/var/lib/postgresql/data
 networks:
   default:
     external: true
     name: shared-network
+
+
+volumes:
+  db-data:

--- a/openweb-ui/docker-compose.yml
+++ b/openweb-ui/docker-compose.yml
@@ -1,17 +1,40 @@
 services:
+  ollama:
+    image: ghcr.io/ollama/ollama:latest
+    container_name: ollama
+    ports:
+      - "11434:11434"
+    volumes:
+      - ./ollama:/root/.ollama
+    restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          memory: 4g
+          cpus: '1.5'
+    networks:
+      - shared-network
+
   open-webui:
     image: ghcr.io/open-webui/open-webui:main
     container_name: open-webui
     ports:
       - "3000:8080"
     environment:
-      - "OLLAMA_BASE_URL=http://host.docker.internal:11434"
+      - "OLLAMA_BASE_URL=http://ollama:11434"
     extra_hosts:
       - "host.docker.internal:host-gateway"
     volumes:
       - ./open-webui:/app/backend/data
-    restart: always
+    restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          memory: 1.5g
+          cpus: '0.5'
+    networks:
+      - shared-network
+
 networks:
-  default:
+  shared-network:
     external: true
-    name: shared-network


### PR DESCRIPTION
…e limits

- Removed unnecessary logs to free up VPS space
- Proposed Docker setup for Ollama with CPU/RAM limits
- Separated Ollama and WebUI into containers with shared network
- Prevent high resource usage by large models (e.g. deepseek-r1:7b)